### PR TITLE
add `demo/output/.gitignore` and `demo/output/clean.sh`

### DIFF
--- a/OpenGait/demo/output/.gitignore
+++ b/OpenGait/demo/output/.gitignore
@@ -1,0 +1,6 @@
+# ignore unnecessary trackings
+demo_video_result/
+GaitFeatures/
+GaitSilhouette/
+InputVideos/
+OutputVideos/

--- a/OpenGait/demo/output/clean.sh
+++ b/OpenGait/demo/output/clean.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# clear all intermediate and final output
+rm ./demo_video_result/* -rf
+rm ./GaitFeatures/* -rf
+rm ./GaitSilhouette/* -rf
+rm ./OutputVideos/* -rf


### PR DESCRIPTION
The new file `demo/output/.gitignore` ignores all input video, intermediate results and final output of demo program, which is unnecessary to track and not conform to the file tracking regulation in git. 

The new file `demo/output/clean.sh` let developer clean all intermediate results and final outputs using one single command `./clean.sh` after executing `chmod +x clean.sh` on Linux.